### PR TITLE
fix(ci): create /etc/cni/net.d before installing minikube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Create the CNI config directory
+      # setup-minikube's none-driver setup runs `chmod 755 /etc/cni/net.d`,
+      # assuming the directory was already created by the podman package that
+      # used to ship in the runner image. It no longer is, so the chmod fails
+      # with "No such file or directory" and the whole step errors out.
+      run: sudo mkdir -p /etc/cni/net.d
     - name: Install minikube
       uses: medyagh/setup-minikube@master
       with:


### PR DESCRIPTION
The weekly CI run started failing in the "Install minikube" step:

    [command]/usr/bin/sudo chmod 755 /etc/cni/net.d
    chmod: cannot access '/etc/cni/net.d': No such file or directory
    ##[error]The process '/usr/bin/sudo' failed with exit code 1

medyagh/setup-minikube runs that chmod as part of its none-driver setup
because the directory used to be created (mode 700, root:root) by the
podman package preinstalled in the ubuntu-latest runner image. That is no
longer the case, so the chmod fails and takes the step down with it.

Create the directory ourselves before the action runs; `sudo mkdir -p`
leaves it at 755 root:root, so the action's chmod becomes a no-op.